### PR TITLE
Update commentaries data zac

### DIFF
--- a/components/HorizontalCommentaries.js
+++ b/components/HorizontalCommentaries.js
@@ -1,0 +1,69 @@
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Text,
+  FlatList,
+  View,
+  ImageBackground
+} from 'react-native';
+
+export default class HorizontalCommentaries extends Component {
+
+  _renderItem = ({ item }) => (
+    <ImageBackground
+      source={{ uri: 'https://images.unsplash.com/photo-1534608176107-b67f671733b3?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2eaaaa01848d4a9c31b21a3b9165af6f&auto=format&fit=crop&w=1052&q=80' }}
+      style={styles.item}
+    >
+      <Text style={styles.itemText}>{item.key}</Text>
+    </ImageBackground>
+  );
+
+  render() {
+    return (
+      <View style={[styles.contentContainer, styles.commentariesContainer]}>
+        <FlatList
+          data={[
+            { key: 'First\nCore Truth' },
+            { key: 'Second\nCore Truth' },
+            { key: 'Third\nCore Truth' },
+            { key: 'Fourth\nCore Truth' },
+            { key: 'Fifth\nCore Truth' },
+        ]}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          renderItem={this._renderItem}
+        />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  contentContainer: {
+    paddingTop: 10,
+    paddingBottom: 20,
+  },
+  commentariesContainer: {
+    flex: 1,
+  },
+  item: {
+    marginLeft: 20,
+    padding: 10,
+    width: 150,
+    height: 120,
+    borderRadius: 7,
+    borderWidth: 1,
+    borderColor: '#fff',
+    overflow: 'hidden',
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  itemText: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: 'bold',
+    fontFamily: 'lato-black',
+    textAlign: 'center',
+  },
+});

--- a/components/HorizontalCommentaries.js
+++ b/components/HorizontalCommentaries.js
@@ -4,11 +4,13 @@ import {
   Text,
   FlatList,
   View,
-  ImageBackground
+  ImageBackground,
+  TouchableOpacity
 } from 'react-native';
+import { connect } from 'react-redux';
 import data from '../constants/CoreTruths.json';
 
-export default class HorizontalCommentaries extends Component {
+class HorizontalCommentaries extends Component {
   constructor(props) {
 		super(props);
 		this.state = {
@@ -16,17 +18,32 @@ export default class HorizontalCommentaries extends Component {
 		};
 	}
 
+  //When an item is clicked, dispatch that items details to the reducer
+  _onPressItem(item) {
+    this.props.dispatch({
+      type: 'LOAD_AUDIO',
+      name: item.name,
+      subtext: item.subtext,
+      image: item.image,
+      audio: item.audio,
+    });
+  //Activate the below line when we're ready to load store in new AudioPlayer
+  //this.props.navigation.navigate('Modal');
+  }
+
   _renderItem = ({ item }) => (
-    <ImageBackground
-      source={{ uri: item.image }}
-      style={styles.item}
-    >
-      <Text style={styles.itemText}>{item.shortname}</Text>
-    </ImageBackground>
+    <TouchableOpacity onPress={() => this._onPressItem(item)}>
+      <ImageBackground
+        source={{ uri: item.image }}
+        style={styles.item}
+      >
+        <Text style={styles.itemText}>{item.shortname}</Text>
+      </ImageBackground>
+    </TouchableOpacity>
   );
 
   render() {
-    console.log(this.state)
+    console.log(this.props.loadedAudio);
     return (
       <View style={styles.contentContainer}>
         <FlatList
@@ -40,6 +57,12 @@ export default class HorizontalCommentaries extends Component {
     );
   }
 }
+
+const mapStateToProps = (state) => {
+	return { loadedAudio: state.loadedAudio };
+};
+
+export default connect(mapStateToProps)(HorizontalCommentaries);
 
 const styles = StyleSheet.create({
   contentContainer: {

--- a/components/HorizontalCommentaries.js
+++ b/components/HorizontalCommentaries.js
@@ -18,7 +18,7 @@ export default class HorizontalCommentaries extends Component {
 
   _renderItem = ({ item }) => (
     <ImageBackground
-      source={{ uri: 'https://images.unsplash.com/photo-1534608176107-b67f671733b3?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2eaaaa01848d4a9c31b21a3b9165af6f&auto=format&fit=crop&w=1052&q=80' }}
+      source={{ uri: item.image }}
       style={styles.item}
     >
       <Text style={styles.itemText}>{item.shortname}</Text>
@@ -28,7 +28,7 @@ export default class HorizontalCommentaries extends Component {
   render() {
     console.log(this.state)
     return (
-      <View style={[styles.contentContainer, styles.commentariesContainer]}>
+      <View style={styles.contentContainer}>
         <FlatList
           data={this.state.data}
           horizontal
@@ -45,9 +45,7 @@ const styles = StyleSheet.create({
   contentContainer: {
     paddingTop: 10,
     paddingBottom: 20,
-  },
-  commentariesContainer: {
-    flex: 1,
+    flex: 1
   },
   item: {
     marginLeft: 20,
@@ -68,5 +66,8 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     fontFamily: 'lato-black',
     textAlign: 'center',
+    textShadowColor: 'rgba(0, 0, 0, 0.75)',
+    textShadowOffset: { width: -1, height: 1 },
+    textShadowRadius: 10
   },
 });

--- a/components/HorizontalCommentaries.js
+++ b/components/HorizontalCommentaries.js
@@ -6,32 +6,35 @@ import {
   View,
   ImageBackground
 } from 'react-native';
+import data from '../constants/CoreTruths.json';
 
 export default class HorizontalCommentaries extends Component {
+  constructor(props) {
+		super(props);
+		this.state = {
+			data,
+		};
+	}
 
   _renderItem = ({ item }) => (
     <ImageBackground
       source={{ uri: 'https://images.unsplash.com/photo-1534608176107-b67f671733b3?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2eaaaa01848d4a9c31b21a3b9165af6f&auto=format&fit=crop&w=1052&q=80' }}
       style={styles.item}
     >
-      <Text style={styles.itemText}>{item.key}</Text>
+      <Text style={styles.itemText}>{item.shortname}</Text>
     </ImageBackground>
   );
 
   render() {
+    console.log(this.state)
     return (
       <View style={[styles.contentContainer, styles.commentariesContainer]}>
         <FlatList
-          data={[
-            { key: 'First\nCore Truth' },
-            { key: 'Second\nCore Truth' },
-            { key: 'Third\nCore Truth' },
-            { key: 'Fourth\nCore Truth' },
-            { key: 'Fifth\nCore Truth' },
-        ]}
+          data={this.state.data}
           horizontal
           showsHorizontalScrollIndicator={false}
           renderItem={this._renderItem}
+          keyExtractor={(item, index) => index.toString()}
         />
       </View>
     );

--- a/constants/CommentariesList.json
+++ b/constants/CommentariesList.json
@@ -34,7 +34,7 @@
         "key": 5,
         "name": "Core Truth #5: Lorem Ipsum",
         "subtext": "6 minutes, 52 seconds",
-        "image": "https://images.unsplash.com/photo-1541753231552-fa0b6f0c4d7c?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2887fd5cf1d3eae72545fe3d8cdd5a04&auto=format&fit=crop&w=500&q=60",
+        "image": "https://images.unsplash.com/photo-1534608176107-b67f671733b3?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2eaaaa01848d4a9c31b21a3b9165af6f&auto=format&fit=crop&w=1052&q=80",
         "audio": "http://russprince.com/hobbies/files/13%20Beethoven%20-%20Fur%20Elise.mp3"
       },
     ]

--- a/constants/CommentariesList.json
+++ b/constants/CommentariesList.json
@@ -14,7 +14,7 @@
         "name": "Core Truth #2: Lorem Ipsum",
         "subtext": "5 minutes, 22 seconds",
         "image": "https://images.unsplash.com/photo-1541796484625-7f5bcba550cc?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ac759f3f244b417ca48e7f15b8e0b7d8&auto=format&fit=crop&w=500&q=60",
-        "audio": "http://russprince.com/hobbies/files/13%20Beethoven%20-%20Fur%20Elise.mp3"      
+        "audio": "http://russprince.com/hobbies/files/13%20Beethoven%20-%20Fur%20Elise.mp3"
       },
       {
         "key": 3,

--- a/constants/CoreTruths.json
+++ b/constants/CoreTruths.json
@@ -36,7 +36,7 @@
     "name": "Core Truth #5: Lorem Ipsum",
     "shortname": "Core\n Truth #5",
     "subtext": "6 minutes, 52 seconds",
-    "image": "https://images.unsplash.com/photo-1541753231552-fa0b6f0c4d7c?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2887fd5cf1d3eae72545fe3d8cdd5a04&auto=format&fit=crop&w=500&q=60",
+    "image": "https://images.unsplash.com/photo-1534608176107-b67f671733b3?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2eaaaa01848d4a9c31b21a3b9165af6f&auto=format&fit=crop&w=1052&q=80",
     "audio": "http://russprince.com/hobbies/files/13%20Beethoven%20-%20Fur%20Elise.mp3"
   },
 ]

--- a/constants/CoreTruths.json
+++ b/constants/CoreTruths.json
@@ -1,0 +1,42 @@
+[
+  {
+    "key": "1",
+    "name": "Core Truth #1: Lorem Ipsum",
+    "shortname": "Core\n Truth #1",
+    "subtext": "8 minutes, 38 seconds",
+    "image": "https://images.unsplash.com/photo-1541832069-e4f383392e1d?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=a561f6a5179df29e8729877d4ff80b32&auto=format&fit=crop&w=500&q=60",
+    "audio": "http://russprince.com/hobbies/files/13%20Beethoven%20-%20Fur%20Elise.mp3"
+  },
+  {
+    "key": "2",
+    "name": "Core Truth #2: Lorem Ipsum",
+    "shortname": "Core\n Truth #2",
+    "subtext": "5 minutes, 22 seconds",
+    "image": "https://images.unsplash.com/photo-1541796484625-7f5bcba550cc?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=ac759f3f244b417ca48e7f15b8e0b7d8&auto=format&fit=crop&w=500&q=60",
+    "audio": "http://russprince.com/hobbies/files/13%20Beethoven%20-%20Fur%20Elise.mp3"
+  },
+  {
+    "key": "3",
+    "name": "Core Truth #3: Lorem Ipsum",
+    "shortname": "Core\n Truth #3",
+    "subtext": "4 minutes, 29 seconds",
+    "image": "https://images.unsplash.com/photo-1541789094913-f3809a8f3ba5?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=6ba555c8bb03ffabb86e6ecf9ec4243c&auto=format&fit=crop&w=500&q=60",
+    "audio": "http://russprince.com/hobbies/files/13%20Beethoven%20-%20Fur%20Elise.mp3"
+  },
+  {
+    "key": "4",
+    "name": "Core Truth #4: Lorem Ipsum",
+    "shortname": "Core\n Truth #4",
+    "subtext": "5 minutes, 32 seconds",
+    "image": "https://images.unsplash.com/photo-1541746951956-4f27df54f02b?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=027b183a2e7e5c8cb657862b34db5530&auto=format&fit=crop&w=500&q=60",
+    "audio": "http://russprince.com/hobbies/files/13%20Beethoven%20-%20Fur%20Elise.mp3"
+  },
+  {
+    "key": "5",
+    "name": "Core Truth #5: Lorem Ipsum",
+    "shortname": "Core\n Truth #5",
+    "subtext": "6 minutes, 52 seconds",
+    "image": "https://images.unsplash.com/photo-1541753231552-fa0b6f0c4d7c?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2887fd5cf1d3eae72545fe3d8cdd5a04&auto=format&fit=crop&w=500&q=60",
+    "audio": "http://russprince.com/hobbies/files/13%20Beethoven%20-%20Fur%20Elise.mp3"
+  },
+]

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -6,6 +6,7 @@ import { createStackNavigator, createAppContainer } from 'react-navigation';
 import PlayerFooter from '../components/PlayerFooter';
 import SectionLabel from '../components/SectionLabel';
 import TextBlock from '../components/TextBlock';
+import HorizontalCommentaries from '../components/HorizontalCommentaries';
 
 export default class HomeScreen extends Component {
   static navigationOptions = {
@@ -46,27 +47,8 @@ export default class HomeScreen extends Component {
           </TouchableWithoutFeedback>
 
           <SectionLabel labelText={'COMMENTARIES'} />
-          <View style={[styles.contentContainer, styles.commentariesContainer]}>
-            <FlatList
-              data={[
-                { key: 'First\nCore Truth' },
-                { key: 'Second\nCore Truth' },
-                { key: 'Third\nCore Truth' },
-                { key: 'Fourth\nCore Truth' },
-                { key: 'Fifth\nCore Truth' },
-            ]}
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              renderItem={({ item }) => (
-                <ImageBackground
-                  source={{ uri: 'https://images.unsplash.com/photo-1534608176107-b67f671733b3?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=2eaaaa01848d4a9c31b21a3b9165af6f&auto=format&fit=crop&w=1052&q=80' }}
-                  style={styles.item}
-                >
-                <Text style={styles.itemText}>{item.key}</Text>
-                </ImageBackground>
-              )}
-            />
-          </View>
+          <HorizontalCommentaries />
+
         </ScrollView>
         <View><PlayerFooter /></View>
       </View>
@@ -82,9 +64,6 @@ const styles = StyleSheet.create({
   contentContainer: {
     paddingTop: 10,
     paddingBottom: 20,
-  },
-  commentariesContainer: {
-    flex: 1,
   },
   nextChapter: {
     flex: 1,
@@ -116,25 +95,5 @@ const styles = StyleSheet.create({
     fontSize: 16,
     marginBottom: 18,
     fontFamily: 'lato-regular',
-  },
-  item: {
-    marginLeft: 20,
-    padding: 10,
-    width: 150,
-    height: 120,
-    borderRadius: 7,
-    borderWidth: 1,
-    borderColor: '#fff',
-    overflow: 'hidden',
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center'
-  },
-  itemText: {
-    color: '#fff',
-    fontSize: 20,
-    fontWeight: 'bold',
-    fontFamily: 'lato-black',
-    textAlign: 'center',
-  },
+  }
 });


### PR DESCRIPTION
1. Split the horizontal scrolling commentaries list into it's own component, separate from the home screen
2. Created a new data source for the component called CoreTruths.json. I tried to use CommentariesList.json as the source, but ran into problems because it has a nested structure that's built for <SectionLists> but can't be read by <FlatLists>
3. Made the tiles touchable, and added Redux to store the loadedAudio data, similar to the Chapters and Commentaries screens

Note: I tried switching the images to all use the same water picture, but it looked weird on the Commentaries page. I went with different pictures for each tile for now, but we can always change that. I'm sure Ted and Kevin will have input on the images as well.

![giphy 9](https://user-images.githubusercontent.com/18668152/49348960-8f3bf080-f665-11e8-9659-0a3ccb4dcb92.gif)



